### PR TITLE
Add patches that mitigate compiler bugs and missing includes for some compiler versions

### DIFF
--- a/external/abseil_patch.diff
+++ b/external/abseil_patch.diff
@@ -1,0 +1,15 @@
+https://github.com/abseil/abseil-cpp/commit/2039d5dff0cef8fe3841519f0418caef6ec47d2d
+diff --git a/absl/strings/internal/damerau_levenshtein_distance.h b/absl/strings/internal/damerau_levenshtein_distance.h
+index 1a9684254aa..7a4bd644626 100644
+--- a/absl/strings/internal/damerau_levenshtein_distance.h
++++ b/absl/strings/internal/damerau_levenshtein_distance.h
+@@ -15,8 +15,7 @@
+ #ifndef ABSL_STRINGS_INTERNAL_DAMERAU_LEVENSHTEIN_DISTANCE_H_
+ #define ABSL_STRINGS_INTERNAL_DAMERAU_LEVENSHTEIN_DISTANCE_H_
+ 
+-#include <numeric>
+-#include <vector>
++#include <cstdint>
+ 
+ #include "absl/strings/string_view.h"
+ 

--- a/external/grpc_patch.diff
+++ b/external/grpc_patch.diff
@@ -1,0 +1,14 @@
+https://github.com/grpc/grpc/pull/31780/commits/18f065b4509e457ca102874830852ecd88b1e177
+diff --git a/src/core/ext/xds/xds_listener.h b/src/core/ext/xds/xds_listener.h
+index 61427483f1888..a3bfed0780cc3 100644
+--- a/src/core/ext/xds/xds_listener.h
++++ b/src/core/ext/xds/xds_listener.h
+@@ -79,6 +79,8 @@ struct XdsListenerResource : public XdsResourceType::ResourceData {
+   };
+ 
+   struct DownstreamTlsContext {
++    DownstreamTlsContext() {}
++
+     CommonTlsContext common_tls_context;
+     bool require_client_certificate = false;
+ 

--- a/ocpdiag/build_deps.bzl
+++ b/ocpdiag/build_deps.bzl
@@ -57,6 +57,8 @@ def load_deps(ocpdiag_package_name = "ocpdiag"):
         url = "https://github.com/abseil/abseil-cpp/archive/64f00b1f4a064e9e140fc4642ccd55c9c2e2e365.zip",  # 2022-11-08
         strip_prefix = "abseil-cpp-64f00b1f4a064e9e140fc4642ccd55c9c2e2e365",
         sha256 = "e7c605119f5aefdf3cd0159f2cbc439c2f7d614c99758be32e0258d49201fc4e",
+        patches = ["abseil_patch.diff"],
+        patch_args = ["-p1"],
     )
 
     maybe(
@@ -101,6 +103,8 @@ def load_deps(ocpdiag_package_name = "ocpdiag"):
         "com_github_grpc_grpc",
         url = "https://github.com/grpc/grpc/archive/refs/tags/v1.51.3.tar.gz",
         strip_prefix = "grpc-1.51.3",
+        patch_args = ["-p1"],
+        patches = ["grpc_patch.diff"],
         sha256 = "feaeeb315133ea5e3b046c2c0231f5b86ef9d297e536a14b73e0393335f8b157",
     )
 


### PR DESCRIPTION
Currently, the `main` branch cannot be compiled due to a [bug](https://stackoverflow.com/questions/53408962/try-to-understand-compiler-error-message-default-member-initializer-required-be) in GCC (also known to exist in Clang). The bug is triggered in an older version of Google's GRPC library (not sure why OCP results library would even require it). This problem is [mitigated](https://github.com/grpc/grpc/pull/31780) in newer versions of grpc, but it is very difficult for us to upgrade the dependencies in ocp-diag-core-cpp at the moment. Thus, I just applied a few cherry-picked patches to our existing dependencies.

Recently, our vendor confirmed that they managed to compile the library with the fix provided in this PR, so I am proposing it for merging.